### PR TITLE
Update midje version

### DIFF
--- a/src/zilti/boot_midje.clj
+++ b/src/zilti/boot_midje.clj
@@ -7,7 +7,7 @@
             [clojure.set :as set]
             [clojure.java.io :as io]))
 
-(def pod-deps '[[midje "1.7.0-SNAPSHOT"]])
+(def pod-deps '[[midje "1.9.0-alpha6"]])
 
 (defn init [config fresh-pod]
   (doto fresh-pod


### PR DESCRIPTION
The former version of midje doesn't work with the new clojure 1.9 alphas, because of an incorrect `ns` declaration