### PR TITLE
create user namespace when pod is initialized

### DIFF
--- a/src/zilti/boot_midje.clj
+++ b/src/zilti/boot_midje.clj
@@ -7,11 +7,12 @@
             [clojure.set :as set]
             [clojure.java.io :as io]))
 
-(def pod-deps '[[midje "1.7.0-SNAPSHOT"]])
+(def pod-deps '[[midje "1.9.9"]])
 
 (defn init [config fresh-pod]
   (doto fresh-pod
     (pod/with-eval-in
+      (create-ns 'user)
       (require 'midje.repl 'midje.util.ecosystem)
       (alter-var-root #'midje.util.ecosystem/leiningen-paths-var (constantly ~(vec (core/get-env :directories))))
       (when (seq ~config)


### PR DESCRIPTION
I had problems using this task with midje "1.9.9". Midje by itself worked fine, but the boot task always complained that it couldnt find the "user" namespace. The line causing the error was (ns-resolve 'user '=>) in the midje.repl namespace. When I add the namespace during initialization of the pod it works fine. 
I assume this line was added recently to Midje causing the boot task to fail. Not sure my changes are the optimal solution to the problem, but I am just glad I got it working with my limited understanding of boot.pods and namespaces in clojure. Maybe it's useful to somebody else.